### PR TITLE
Broaden how many frames are examined for truncated_callstack? on JRuby o...

### DIFF
--- a/cli/ruby-debug/commands/frame.rb
+++ b/cli/ruby-debug/commands/frame.rb
@@ -140,7 +140,11 @@ module Debugger
         if cs.size > recorded_size+2 && cs[recorded_size+2] != sentinal 
           # caller seems to truncate recursive calls and we don't.
           # See if we can find sentinal in the first 0..recorded_size+1 entries
-          return false if cs[0..recorded_size+1].any?{ |f| f==sentinal }
+          if defined? JRUBY_VERSION
+            return false if cs.any? { |f| f==sentinal }
+          else
+            return false if cs[0..recorded_size+1].any?{ |f| f==sentinal }
+          end
           return cs
         end
         return false


### PR DESCRIPTION
This PR is a little strange but I constantly see the truncated callstack on JRuby.  The logic in truncated_callstack? is not searching far enough to see the sentinal.  This could be a bug in JRuby not pushing enough frames onto context?  I am unsure and I am just starting to learn stuff in this codebase.  By searching all remaining frames it seems to find it ok.  Without this fix I get constant warnings and it makes many tests fail.
