### PR TITLE
nil can sometimes exist in context stack in 1.9...Even if this is not th...

### DIFF
--- a/src/org/jruby/debug/Debugger.java
+++ b/src/org/jruby/debug/Debugger.java
@@ -272,7 +272,7 @@ final class Debugger {
         
         int len = contexts.getLength();
         for (int i = 0; i < len; i++) {
-            Context context = (Context)contexts.entry(i);
+            Object context = contexts.entry(i);
             if (context == current) {
                 contexts.remove(i);
             }


### PR DESCRIPTION
...e case we have no reason to cast here since we only care about object equality

It could be a bug that contexts are nil at times but the commit itself should be fine regardless since we only care about a match against a specific object. 
