### PR TITLE
linecache only for JRuby uses entries which only exists on String in 1.8...

### DIFF
--- a/lib/ruby-debug-base.rb
+++ b/lib/ruby-debug-base.rb
@@ -299,3 +299,13 @@ class Module
     EOD
   end
 end
+
+# Work around linecache implementation using entries on JRuby
+if defined? JRUBY_VERSION && JRUBY_VERSION > 1.8
+  class String
+    def entries
+      each_line.to_a
+    end
+  end
+end
+


### PR DESCRIPTION
... (Enumerable no longer mixed into string).  This adds a reasonably compatible version.

I admit this is a little crappy. I could try and submit this to linecache, but linecache is stated that it will not work in 1.9, but we don't actually use the native extension part of linecache in JRuby.  Adding this tiny monkey patch fixes things adequately for JRuby.  Also, this version of ruby-debug is nearly as green as the 1.8 version, so I would like to minimally patch this gem for JRuby can have a working ruby-debug gem which works regardless of which mode is used: --1.8,--1.9,or --2.0.
