### PR TITLE
In 1.9 variables are symbols and not strings.  Call to_s to make it 1.9 ...

### DIFF
--- a/cli/ruby-debug/commands/variables.rb
+++ b/cli/ruby-debug/commands/variables.rb
@@ -4,10 +4,10 @@ module Debugger
       ary.sort!
       for v in ary
         begin
-          s = debug_eval(v, b).inspect
+          s = debug_eval(v.to_s, b).inspect
         rescue
           begin
-            s = debug_eval(v, b).to_s
+            s = debug_eval(v.to_s, b).to_s
           rescue
             s = "*Error in evaluation*"
           end


### PR DESCRIPTION
...friendly

This is a harmless fix which makes JRuby now run as well as in 1.8 mode in 1.9 mode.  Both modes are failing the same tests now and the errors are similar (and largely I think JRuby compat problems)
