### PR TITLE
code changes for Ruboto compatibility...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Gemfile.lock
 .ruby-gemset
 .ruby-version
 .idea/*
+.*.un~
+.*.swp

--- a/cli/ruby-debug/commands/irb.rb
+++ b/cli/ruby-debug/commands/irb.rb
@@ -1,3 +1,5 @@
+begin # rescue ArgumentError
+
 require 'irb'
 
 module IRB # :nodoc:
@@ -153,7 +155,7 @@ module Debugger
       else
         file = @state.context.frame_file(0)
         line = @state.context.frame_line(0)
-        CommandProcessor.print_location_and_text(file, line)
+        @state.processor.print_location_and_text(file, line)
         @state.previous_line = nil
       end
 
@@ -188,5 +190,9 @@ dbgr ['list', '10']   # same as "list 10" inside debugger
       end
     end
   end
+end
+
+rescue ArgumentError
+  # (GF) require 'irb' raises ArgumentError attempting to load readline in JRuby on Android
 end
 

--- a/cli/ruby-debug/interface.rb
+++ b/cli/ruby-debug/interface.rb
@@ -13,7 +13,7 @@ module Debugger
         require 'readline'
         @have_readline = true
         @history_save = true
-      rescue LoadError
+      rescue LoadError, ArgumentError
         @have_readline = false
         @history_save = false
       end
@@ -132,7 +132,7 @@ module Debugger
       def readline(prompt, hist)
         Readline::readline(prompt, hist)
       end
-    rescue LoadError
+    rescue LoadError, ArgumentError
       def readline(prompt, hist)
         @histfile = ''
         @hist_save = false

--- a/cli/ruby-debug/processor.rb
+++ b/cli/ruby-debug/processor.rb
@@ -114,8 +114,9 @@ module Debugger
       end
     end
 
-    def self.print_location_and_text(file, line)
-      file_line = "%s:%s\n%s" % [canonic_file(file), line, 
+    # (GF) made this an instance method so #print calls @interface#print
+    def print_location_and_text(file, line)
+      file_line = "%s:%s\n%s" % [CommandProcessor.canonic_file(file), line, 
                                  Debugger.line_at(file, line)]
       # FIXME: use annotations routines
       if Debugger.annotate.to_i > 2
@@ -306,7 +307,7 @@ module Debugger
       end
       
       preloop(@commands, context)
-      CommandProcessor.print_location_and_text(file, line)
+      print_location_and_text(file, line)
       while !state.proceed? 
         input = if @interface.command_queue.empty?
                   @interface.read_command(prompt(context))

--- a/ruby-debug.gemspec
+++ b/ruby-debug.gemspec
@@ -30,7 +30,7 @@ EOF
     'rdbg.rb']
 
   spec.add_dependency 'columnize', '>= 0.1'
-  spec.add_dependency 'linecache', '~> 0.46'
+  spec.add_dependency 'linecache', '~> 1.3.1'
   spec.add_dependency 'ruby-debug-base', "~> #{Debugger::VERSION}.0"
 
   spec.extra_rdoc_files = ['README']


### PR DESCRIPTION
readline raises Argument error: add to rescues
require irb raises Argument error (readline again): wrap irb.rb to rescue
Processor.print_location_and_text calls Kernel.print sending output to application stdout: make print_location_and_text an instance method so print will call Interface#print and send output to debugger client
linecache-1.3.1 updated for Ruboto compatibility: update gem dependency