### PR TITLE
Add mention of licenses to the gemspec files

### DIFF
--- a/ruby-debug-base.gemspec
+++ b/ruby-debug-base.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.email = "ksibilev@yahoo.com"
   spec.homepage = "https://github.com/ruby-debug/"
   spec.summary = "Fast Ruby debugger - core component"
+  spec.license = "MIT"
   spec.description = <<-EOF
 ruby-debug is a fast implementation of the standard Ruby debugger debug.rb.
 It is implemented by utilizing a new Ruby C API hook. The core component

--- a/ruby-debug.gemspec
+++ b/ruby-debug.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
   spec.email = "ksibilev@yahoo.com"
   spec.homepage = "https://github.com/ruby-debug/"
   spec.summary = "Command line interface (CLI) for ruby-debug-base"
+  spec.license = "MIT"
   spec.description = <<-EOF
 A generic command line interface for ruby-debug.
 EOF

--- a/ruby-debug.gemspec
+++ b/ruby-debug.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email = "ksibilev@yahoo.com"
   spec.homepage = "https://github.com/ruby-debug/"
   spec.summary = "Command line interface (CLI) for ruby-debug-base"
-  spec.license = "MIT"
+  spec.license = "Simplified BSD"
   spec.description = <<-EOF
 A generic command line interface for ruby-debug.
 EOF


### PR DESCRIPTION
I think that the LICENSE file is simplified BSD (aka BSD 2-clause) even though it mentions the Regents instead of the copyright holder. Probably because it's at least 14 years old.