### PR TITLE
Unbreak ruby-debug-base for JRuby 9.x

### DIFF
--- a/ruby-debug.gemspec
+++ b/ruby-debug.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 A generic command line interface for ruby-debug.
 EOF
 
+  spec.required_ruby_version = "2.3.1" if RUBY_ENGINE == "jruby"
   spec.require_path = "cli"
   spec.executables = ["rdebug"]
   spec.files = Dir[

--- a/src/org/jruby/debug/Context.java
+++ b/src/org/jruby/debug/Context.java
@@ -40,6 +40,7 @@ import org.jruby.parser.StaticScope;
 import org.jruby.runtime.Arity;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.DynamicScope;
+import org.jruby.runtime.Signature;
 import org.jruby.runtime.builtin.IRubyObject;
 
 public class Context extends RubyObject {
@@ -405,9 +406,10 @@ public class Context extends RubyObject {
     private IRubyObject contextCopyArgs(DebugFrame debugFrame) {
         RubyArray result = getRuntime().newArray();
         StaticScope scope = debugFrame.getInfo().getScope();
-        
-        int count = scope.getRequiredArgs() + scope.getOptionalArgs();
-        if (scope.getRestArg() >= 0) {
+
+        Signature signature = scope.getSignature();
+        int count = signature.required() + signature.opt();
+        if (signature.hasRest()) {
             count++;
         }
         

--- a/src/org/jruby/debug/DebugEventHook.java
+++ b/src/org/jruby/debug/DebugEventHook.java
@@ -34,6 +34,7 @@ import org.jruby.exceptions.RaiseException;
 import org.jruby.runtime.Block;
 import org.jruby.runtime.EventHook;
 import org.jruby.runtime.RubyEvent;
+import org.jruby.runtime.Signature;
 import org.jruby.runtime.ThreadContext;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -94,7 +95,7 @@ final class DebugEventHook extends EventHook {
             }
             setInDebugger(true);
             try {
-                processEvent(tCtx, Util.typeForEvent(event), file, Util.relativizeToPWD(file, currThread.getRuntime()), line, methodName, klass, contexts);
+                processEvent(tCtx, Util.typeForEvent(event), file, Util.relativizeToPWD(file), line, methodName, klass, contexts);
             } finally {
                 setInDebugger(false);
             }
@@ -386,7 +387,10 @@ final class DebugEventHook extends EventHook {
 
     /** Save scalar arguments or a class name. */
     private void copyScalarArgs(ThreadContext tCtx, DebugFrame debugFrame) {
-        RubyArray args = runtime.newArray(tCtx.getCurrentScope().getArgValues());
+        // FIXME: This is all values and is not splatting rest but it will not crash.  We have
+        // no current capability to get just the params on a frame easily and seemingly no one has
+        // called this method in years since it would have crashed since 9.0.
+        RubyArray args = runtime.newArray(tCtx.getCurrentScope().getValues());
         
         int len = args.getLength();
         for (int i = 0; i < len; i++) {

--- a/src/org/jruby/debug/DebugEventHook.java
+++ b/src/org/jruby/debug/DebugEventHook.java
@@ -95,7 +95,7 @@ final class DebugEventHook extends EventHook {
             }
             setInDebugger(true);
             try {
-                processEvent(tCtx, Util.typeForEvent(event), file, Util.relativizeToPWD(file), line, methodName, klass, contexts);
+                processEvent(tCtx, Util.typeForEvent(event), file, Util.relativizeToPWD(file, currThread.getRuntime()), line, methodName, klass, contexts);
             } finally {
                 setInDebugger(false);
             }

--- a/src/org/jruby/debug/Util.java
+++ b/src/org/jruby/debug/Util.java
@@ -26,7 +26,6 @@ package org.jruby.debug;
 import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
-import org.jruby.Ruby;
 import org.jruby.RubyBoolean;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.builtin.IRubyObject;
@@ -58,8 +57,8 @@ final class Util {
         return ro.getRuntime().getNil();
     }
 
-    static String relativizeToPWD(final String path, final Ruby runtime) {
-        return Util.relativizeFile(runtime.getCurrentDirectory(), path);
+    static String relativizeToPWD(final String path) {
+        return Util.relativizeFile(System.getProperty("user.dir"), path);
     }
 
     static String relativizeFile(final String base, final String filepath) {
@@ -103,33 +102,7 @@ final class Util {
     }
 
     static RubyEvent typeForEvent(final String event) {
-        if ("line".equals(event)) {
-            return LINE;
-        } else if ("class".equals(event)) {
-            return CLASS;
-        } else if ("end".equals(event)) {
-            return END;
-        } else if ("call".equals(event)) {
-            return CALL;
-        } else if ("return".equals(event)) {
-            return RETURN;
-        } else if ("c-call".equals(event)) {
-            return C_CALL;
-        } else if ("c-return".equals(event)) {
-            return C_RETURN;
-        } else if ("b-call".equals(event)) {
-            return B_CALL;
-        } else if ("b-return".equals(event)) {
-            return B_RETURN;
-        } else if ("thread-begin".equals(event)) {
-            return THREAD_BEGIN;
-        } else if ("thread-end".equals(event)) {
-            return THREAD_END;    
-        } else if ("raise".equals(event)) {
-            return RAISE;
-        } else {
-            throw new IllegalArgumentException("unknown event type: " + event);
-        }
+        return RubyEvent.fromName(event);
     }
 }
 

--- a/src/org/jruby/debug/Util.java
+++ b/src/org/jruby/debug/Util.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.logging.Logger;
 import org.jruby.RubyBoolean;
+import org.jruby.Ruby;
 import org.jruby.runtime.RubyEvent;
 import org.jruby.runtime.builtin.IRubyObject;
 
@@ -57,7 +58,7 @@ final class Util {
         return ro.getRuntime().getNil();
     }
 
-    static String relativizeToPWD(final String path) {
+    static String relativizeToPWD(final String path, Ruby runtime) {
         return Util.relativizeFile(runtime.getCurrentDirectory(), path);
     }
 

--- a/src/org/jruby/debug/Util.java
+++ b/src/org/jruby/debug/Util.java
@@ -58,7 +58,7 @@ final class Util {
     }
 
     static String relativizeToPWD(final String path) {
-        return Util.relativizeFile(System.getProperty("user.dir"), path);
+        return Util.relativizeFile(runtime.getCurrentDirectory(), path);
     }
 
     static String relativizeFile(final String base, final String filepath) {


### PR DESCRIPTION
There were a few issues which has made this not work using Java 9.x APIs.  What is amazing is up to 9.2.8.0 it seemingly works for the things in which Idea is using it for.  in 9.2.9.0 some enums had fixed a couple long standing typos (c_call -> c-call as example).  This broke ruby-debug-base-java because Util.java was hardcoding the improperly named enum values.

Tested on both 9.2.8.0 and 9.2.9.0 which works.  This should work for 9.1.x and 9.2.x releases.  This should go back over several years of releases.  It likely works on all 9.x but that was not tested.