### PR TITLE
now compatible with JRuby 10.0.0.0 and up

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,14 +63,14 @@ task :default => :test
 desc "Remove built files"
 task :clean do
   cd "ext" do
-    if File.exists?("Makefile")
+    if File.exist?("Makefile")
       sh "make clean"
       rm  "Makefile"
     end
     derived_files = Dir.glob(".o") + Dir.glob("*.so")
     rm derived_files unless derived_files.empty?
   end
-  rm 'lib/ruby_debug.jar' if File.exists?("lib/ruby_debug.jar")
+  rm 'lib/ruby_debug.jar' if File.exist?("lib/ruby_debug.jar")
 end
 
 desc "Generate rdoc documentation"

--- a/bin/rdebug
+++ b/bin/rdebug
@@ -249,7 +249,7 @@ EOB
             'Name of the script file to run. Erased after read') do 
       |restart_script|
       options.restart_script = restart_script
-      unless File.exists?(options.restart_script)
+      unless File.exist?(options.restart_script)
         puts "Script file '#{options.restart_script}' is not found"
         exit
       end
@@ -257,7 +257,7 @@ EOB
     opts.on('--script FILE', String, 'Name of the script file to run') do 
       |script|
       options.script = script
-      unless File.exists?(options.script)
+      unless File.exist?(options.script)
         puts "Script file '#{options.script}' is not found"
         exit
       end

--- a/cli/ruby-debug.rb
+++ b/cli/ruby-debug.rb
@@ -151,10 +151,10 @@ module Debugger
     # directory where you invoke ruby-debug.
     def run_init_script(out = handler.interface)
       cwd_script_file  = File.expand_path(File.join(".", INITFILE))
-      run_script(cwd_script_file, out) if File.exists?(cwd_script_file)
+      run_script(cwd_script_file, out) if File.exist?(cwd_script_file)
 
       home_script_file = File.expand_path(File.join(HOME_DIR, INITFILE))
-      run_script(home_script_file, out) if File.exists?(home_script_file) and 
+      run_script(home_script_file, out) if File.exist?(home_script_file) and 
         cwd_script_file != home_script_file
     end
 

--- a/src/org/jruby/debug/DebugEventHook.java
+++ b/src/org/jruby/debug/DebugEventHook.java
@@ -324,6 +324,8 @@ final class DebugEventHook extends EventHook {
                 break;
             case THREAD_BEGIN:
             case THREAD_END:
+            case RESCUE:
+            case A_RETURN:
                 break;    
             default:
                 throw new IllegalArgumentException("unknown event type: " + event);

--- a/src/org/jruby/debug/RubyDebugBaseLibrary.java
+++ b/src/org/jruby/debug/RubyDebugBaseLibrary.java
@@ -41,7 +41,7 @@ public final class RubyDebugBaseLibrary implements Library {
         private static final long serialVersionUID = 1L;
 
         protected DebugThread(Ruby runtime, RubyClass type) {
-            super(runtime, type);
+            super(runtime, type, false);
         }
         
         @JRubyMethod(name="inherited", required=1, meta=true)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,7 +21,7 @@ module TestHelper
       debug_pgm = opts[:runner]    || 'tdebug.rb'
       filter    = opts[:filter]
 
-      if File.exists?(outfile)
+      if File.exist?(outfile)
         FileUtils.rm(outfile)
       end
 
@@ -53,7 +53,7 @@ module TestHelper
 
   def rightfile(testname)
     jruby_file = File.join('data', "#{testname}-jruby.right")
-    if defined?(JRUBY_VERSION) && File.exists?(jruby_file)
+    if defined?(JRUBY_VERSION) && File.exist?(jruby_file)
       jruby_file
     else
       File.join('data', "#{testname}.right")
@@ -141,7 +141,7 @@ module TestHelper
   # Loads key from the _config_._yaml_ file.
   def config_load(key, may_be_nil=false, default_value='')
     conf = File.join('config.private.yaml') # try private first
-    unless File.exists?(conf)
+    unless File.exist?(conf)
       if defined?(JRUBY_VERSION)
         conf = File.join('config.jruby.yaml')
       else

--- a/test/tdebug.rb
+++ b/test/tdebug.rb
@@ -132,7 +132,7 @@ EOB
   end
   opts.on("--script FILE", String, "Name of the script file to run") do |script|
     options.script = script
-    unless File.exists?(options.script)
+    unless File.exist?(options.script)
       puts "Script file '#{options.script}' is not found"
       exit
     end


### PR DESCRIPTION
fixes https://youtrack.jetbrains.com/issue/RUBY-34161/Debug-fails-to-start-for-JRuby-10.0.0

the primary change is adding RESCUE and A_RETURN to the list of events to be ignored

Also changes Files.exists? to File.exist? everywhere

Also need to fix the DebugThread super call to get things to compile by passing `false`, to mimic the behavior of the old two-argument constructor
